### PR TITLE
Add case insensitive string search

### DIFF
--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -250,6 +250,7 @@ void SearchWidget::refreshSearchspaces()
     ui->searchspaceCombo->clear();
     ui->searchspaceCombo->addItem(tr("asm code"), QVariant("/acj"));
     ui->searchspaceCombo->addItem(tr("string"), QVariant("/j"));
+    ui->searchspaceCombo->addItem(tr("string (case insensitive)"), QVariant("/ij"));
     ui->searchspaceCombo->addItem(tr("hex string"), QVariant("/xj"));
     ui->searchspaceCombo->addItem(tr("ROP gadgets"), QVariant("/Rj"));
     ui->searchspaceCombo->addItem(tr("32bit value"), QVariant("/vj"));
@@ -297,13 +298,16 @@ void SearchWidget::updatePlaceholderText(int index)
     case 1: // string
         ui->filterLineEdit->setPlaceholderText("foobar");
         break;
-    case 2: // hex string
+    case 2: // string (case insensitive)
+        ui->filterLineEdit->setPlaceholderText("FooBar");
+        break;
+    case 3: // hex string
         ui->filterLineEdit->setPlaceholderText("deadbeef");
         break;
-    case 3: // ROP gadgets
+    case 4: // ROP gadgets
         ui->filterLineEdit->setPlaceholderText("pop,,pop");
         break;
-    case 4: // 32bit value
+    case 5: // 32bit value
         ui->filterLineEdit->setPlaceholderText("0xdeadbeef");
         break;
     default:


### PR DESCRIPTION
Not familiar enough with rizin, very much assuming this works without building cutter*. I trust the documentation for rizin is correct and case insensitive search works.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

Adds the case insensitive string search option, currently the existing dropdown forces case sensitivity. Makes searching for strings difficult when the string is known but the exact casing might not be.

Note: case insensitivity could be a checkbox or something else where applicable. Rewrite as needed.

**Test plan (required)**

Double check that if a known string exists in a program that the search results are listed as expected. Alternate character's casing in the search bar, the same results should appear.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
